### PR TITLE
update documentation for Jekyll 3.5.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@
 2. And the following to your site's `_config.yml`:
 
     ```yml
-    gems:
+    plugins:
       - jekyll-default-layout
     ```
+
+Note: If you are using a Jekyll version less than 3.5.0, use the `gems` key instead of `plugins`.
 
 ## What it does
 


### PR DESCRIPTION
We are now at 3.8.3 of Jekyll, with Github Pages using v3.7.3. this change should be a no brainer, but figured it might be useful to note what the mainly used versions are likely to be in relation to v3.5.0