### PR TITLE
Modernize CI matrix and dependencies

### DIFF
--- a/.github/workflows/ci.rubocop.yml
+++ b/.github/workflows/ci.rubocop.yml
@@ -1,7 +1,0 @@
-inherit_from: ../../.rubocop.yml
-
-# Disable problematic cops with incompatible configurations
-FactoryBot/CreateList:
-  Enabled: false
-RSpecRails/NegationBeValid:
-  Enabled: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,27 +4,37 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.0']
-        jekyll-version: ["~> 3.0", "~> 4.0"]
+        ruby_version:
+          - "3.3"
+          - "4.0"
+        jekyll_version:
+          - "~> 3.0"
+          - "~> 4.0"
+        exclude:
+          # Jekyll 3.x is not compatible with Ruby 4.0; GitHub Pages still
+          # ships Jekyll 3.x, so keep testing it on the newest Ruby that
+          # supports it (3.3).
+          - ruby_version: "4.0"
+            jekyll_version: "~> 3.0"
+
+    env:
+      JEKYLL_VERSION: ${{ matrix.jekyll_version }}
 
     steps:
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby-version }}
-          bundler-cache: true
-        env:
-          JEKYLL_VERSION: ${{ matrix.jekyll-version }}
+    - name: Set up Ruby ${{ matrix.ruby_version }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby_version }}
+        bundler-cache: true # Runs bundle install and caches installed gems
 
-      - name: Run tests
-        run: script/cibuild
+    - name: Run tests
+      run: script/cibuild

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]
-
-# Pin specific versions to avoid compatibility issues
-gem "rubocop-factory_bot", "= 2.24.0"

--- a/jekyll-default-layout.gemspec
+++ b/jekyll-default-layout.gemspec
@@ -20,8 +20,16 @@ Gem::Specification.new do |s|
   s.add_development_dependency "kramdown-parser-gfm", "~> 1.0"
   s.add_development_dependency "rspec", "~> 3.5"
   s.add_development_dependency "rubocop", "~> 1.0"
-  s.add_development_dependency "rubocop-factory_bot", "~> 2.22.0"
+  s.add_development_dependency "rubocop-factory_bot", "~> 2.26.0"
   s.add_development_dependency "rubocop-jekyll", "~> 0.11"
   s.add_development_dependency "rubocop-performance", "~> 1.6"
   s.add_development_dependency "rubocop-rspec", "~> 3.0"
+  # No longer default gems as of recent Rubies; required transitively by
+  # RuboCop and Jekyll's dependencies (e.g. safe_yaml needs base64 on Ruby
+  # 3.4+, RuboCop needs benchmark/ostruct on Ruby 4.0).
+  s.add_development_dependency "base64"
+  s.add_development_dependency "benchmark"
+  s.add_development_dependency "ostruct"
+  s.add_development_dependency "tsort"
+  s.required_ruby_version = ">= 3.0"
 end


### PR DESCRIPTION
Brings jekyll-default-layout in line with the other `github-pages` core plugins.

- Ruby **3.3 + 4.0** × Jekyll **3.x + 4.x** (drop EOL 2.7/3.0); `checkout` v2→v4; `fail-fast: false`; `JEKYLL_VERSION` moved to job-level env.
- Remove `.github/workflows/ci.rubocop.yml` — a misplaced RuboCop config, not a valid workflow.
- gemspec: bump `rubocop-factory_bot` to `~> 2.26.0` (**supersedes #39**), add `base64`/`benchmark`/`ostruct`/`tsort` (Ruby 4.0), declare `required_ruby_version >= 3.0`. Drop the stale Gemfile pin.

**Verified:** `script/cibuild` green on Ruby 4.0.6 + Jekyll `~> 4.0`.

> Branch-protection required checks will be repointed to the new job names on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)