### PR TITLE
Add optional default layouts for HTML pages (reimplements #35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Gemfile.lock
 spec/fixtures/site/.jekyll-cache/
 vendor/
 .bundle/
+vendor/bundle/

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ What layout is used:
 * A post - the post layout or the default layout, if they exist, in that order
 * A collection document - a layout matching the collection name or the default layout, if they exist, in that order
 
+## HTML pages
+
+By default, the plugin only applies layouts to Markdown files. To also apply layouts to HTML files that don't specify one, opt in via your `_config.yml`:
+
+```yml
+jekyll-default-layout:
+  html_pages: true
+```
+
 ## Disabling
 
 For a specific post or page, add `layout: null` to the front matter.

--- a/lib/jekyll-default-layout/generator.rb
+++ b/lib/jekyll-default-layout/generator.rb
@@ -22,7 +22,8 @@ module JekyllDefaultLayout
     end
 
     def should_set_layout?(document)
-      markdown?(document) && !layout_specified?(document)
+      !layout_specified?(document) &&
+        (markdown?(document) || (html?(document) && html_pages_enabled?))
     end
 
     # Does the given layout exist for the site?
@@ -38,6 +39,17 @@ module JekyllDefaultLayout
 
     def markdown?(document)
       markdown_converter.matches(document.extname)
+    end
+
+    def html?(document)
+      document.extname == ".html"
+    end
+
+    # HTML pages are only given a default layout when the user opts in via
+    # `jekyll-default-layout: { html_pages: true }` in _config.yml.
+    def html_pages_enabled?
+      config = site.config["jekyll-default-layout"]
+      config.is_a?(Hash) && config["html_pages"] == true
     end
 
     # What layout is appropriate for this document, if any

--- a/spec/jekyll-default-layout/generator_spec.rb
+++ b/spec/jekyll-default-layout/generator_spec.rb
@@ -55,6 +55,15 @@ RSpec.describe JekyllDefaultLayout::Generator do
     expect(subject.markdown?(html_file)).to be(false)
   end
 
+  it "knows a file is an HTML file" do
+    expect(subject.html?(page)).to be(false)
+    expect(subject.html?(html_file)).to be(true)
+  end
+
+  it "knows HTML pages support is disabled by default" do
+    expect(subject.html_pages_enabled?).to be(false)
+  end
+
   it "knows when a layout's been specified" do
     expect(subject.layout_specified?(page)).to be(false)
     expect(subject.layout_specified?(page_with_layout)).to be(true)
@@ -148,12 +157,21 @@ RSpec.describe JekyllDefaultLayout::Generator do
       expect(subject.should_set_layout?(page)).to be(true)
     end
 
-    it "knows not to set the layout for html files" do
+    it "knows not to set the layout for html files by default" do
       expect(subject.should_set_layout?(html_file)).to be(false)
     end
 
     it "knows not to set the layout for files with layouts" do
       expect(subject.should_set_layout?(page_with_layout)).to be(false)
+    end
+
+    context "with html_pages enabled" do
+      let(:overrides) { { "jekyll-default-layout" => { "html_pages" => true } } }
+
+      it "sets the layout for HTML files" do
+        expect(subject.html_pages_enabled?).to be(true)
+        expect(subject.should_set_layout?(html_file)).to be(true)
+      end
     end
   end
 
@@ -203,6 +221,14 @@ RSpec.describe JekyllDefaultLayout::Generator do
 
       it "doesn't mangle HTML files" do
         expect(content_of_file("file.html")).not_to match("LAYOUT")
+      end
+
+      context "with html_pages enabled" do
+        let(:overrides) { { "jekyll-default-layout" => { "html_pages" => true } } }
+
+        it "applies the layout to HTML files" do
+          expect(content_of_file("file.html")).to match("PAGE LAYOUT")
+        end
       end
 
       context "with front matter defaults" do


### PR DESCRIPTION
Adds opt-in default-layout support for `.html` pages:

```yml
jekyll-default-layout:
  html_pages: true
```

Off by default, so existing Markdown-only behavior is unchanged. Adds `html?` and `html_pages_enabled?` helpers and extends `should_set_layout?`, with tests (40 examples, up from 36).

Reimplements **#35** cleanly onto the modernized `main` — that PR also accidentally committed an entire `vendor/bundle/` tree, and had a couple of RuboCop issues (double-negation, trailing whitespace) which are cleaned up here. **Closes #35.**

**Verified:** `script/cibuild` green on Ruby 4.0.6 + Jekyll `~> 4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)