### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## 0.2.0
+
+### Features
+
+- Apply default layouts to Jekyll collection documents (a layout matching the
+  collection name, falling back to `default`)
+- Optionally apply default layouts to HTML pages — opt in with
+  `jekyll-default-layout: { html_pages: true }` in `_config.yml` (off by
+  default) (#41)
+
+### Dependencies
+
+- Bump `rubocop-factory_bot` to `~> 2.26.0` (#40)
+- Add `base64`/`benchmark`/`ostruct`/`tsort` dev deps (no longer default gems
+  on Ruby 4.0)
+- Declare `required_ruby_version >= 3.0`
+
+### Infrastructure
+
+- Modernize CI — test Ruby 3.3 & 4.0 against Jekyll 3.x & 4.x; drop EOL
+  2.7/3.0; `actions/checkout` v2 → v4 (#40)
+- Remove a misplaced RuboCop config from `.github/workflows/`
+- Stop tracking vendored gems

--- a/lib/jekyll-default-layout/version.rb
+++ b/lib/jekyll-default-layout/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JekyllDefaultLayout
-  VERSION = "0.1.5"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
Prepares **v0.2.0** (minor — new features). Adds a `CHANGELOG.md` (none existed). Publish is a manual `gem push` after merge.

**Bump:** 0.1.5 → 0.2.0

### Changelog
**Features**
- Apply default layouts to collection documents
- Optional default layouts for HTML pages (`html_pages: true`, opt-in) (#41)

**Dependencies**
- `rubocop-factory_bot ~> 2.26.0` (#40); add `base64`/`benchmark`/`ostruct`/`tsort`; `required_ruby_version >= 3.0`

**Infrastructure**
- Modernize CI (Ruby 3.3 & 4.0 × Jekyll 3.x & 4.x) (#40); remove misplaced RuboCop config; stop tracking vendored gems

🤖 Generated with [Claude Code](https://claude.com/claude-code)